### PR TITLE
Add docs for legacy failures

### DIFF
--- a/LEGACY.md
+++ b/LEGACY.md
@@ -1,0 +1,25 @@
+# Legacy Support
+
+## Patch fails with errors
+
+### Build errors
+
+You get errors from the patch that look like this:
+
+```
+OSX version:10.13 / arch:x86_64
+Binary is a fat binary with 2 archs.
+dyld: lazy symbol binding failed: Symbol not found: ____chkstk_darwin
+  Referenced from: /Users/myusername/Downloads/rsbypass/RSBypass/./insert_dylib (which was built for Mac OS X 12.0)
+  Expected in: /usr/lib/libSystem.B.dylib
+
+dyld: Symbol not found: ____chkstk_darwin
+  Referenced from: /Users/myusername/Downloads/rsbypass/RSBypass/./insert_dylib (which was built for Mac OS X 12.0)
+  Expected in: /usr/lib/libSystem.B.dylib
+```
+
+If you're getting this error, it means that the patch was built for an older
+version of OSX and will not run on your machine as is.
+
+You can try running the old patch, found here:
+https://cdn.discordapp.com/attachments/631523444588019767/1017232040527155230/MAC_Patch.zip

--- a/RUN_PATCH_RS.command
+++ b/RUN_PATCH_RS.command
@@ -1,6 +1,7 @@
 RS_PATH="/Users/$USER/Library/Application Support/Steam/steamapps/common/Rocksmith2014/Rocksmith2014.app/Contents/MacOS"
 OSX_VERSION=$(sw_vers -productVersion | cut -d '.' -f 1,2)
 ARCH=$(uname -m)
+LEGACY_LINK="https://github.com/aik002/RSBypass/blob/main/LEGACY.md"
 echo "OSX version:$OSX_VERSION / arch:$ARCH"
 
 if test "$ARCH" = 'arm64'; then
@@ -9,6 +10,7 @@ elif test "$ARCH" = 'i386'; then
     DYLIB_FOLDER=x86
 elif [ 1 -eq "$(echo "${OSX_VERSION} < 10.14" | bc -l)" ]; then # Older than Monterey (12.0) 
     DYLIB_FOLDER=x64.Legacy
+    echo "You are on an old architecture that might not work.  Please see $LEGACY_LINK for details"
 else
     DYLIB_FOLDER=x64
 fi


### PR DESCRIPTION
Specifically for older architectures.

This failed for me on an old machine, and with these errors.  Using the older
patch was the fix.